### PR TITLE
Add missing <cstdio> include

### DIFF
--- a/sctpthread.cpp
+++ b/sctpthread.cpp
@@ -19,6 +19,7 @@
  */
 
 #include <chrono>
+#include <cstdio>
 #include <algorithm>
 
 #include <string.h>


### PR DESCRIPTION
This header defines EOF macro. Some toolchains cannot
find this macro, if <cstdio> is missing. So include it
explicitly.

Signed-off-by: Yegor Yefremov <yegorslists@googlemail.com>