### PR TITLE
logging: use correct type for pos

### DIFF
--- a/logging.h
+++ b/logging.h
@@ -28,8 +28,11 @@
 using namespace cannelloni;
 
 inline std::string splitFilename(const std::string &path) {
-  uint16_t pos = path.find_last_of("/\\");
-  return path.substr(pos+1);
+  size_t pos = path.find_last_of("/\\");
+  if (pos == std::string::npos)
+    return path;
+  else
+    return path.substr(pos+1);
 }
 
 #define FUNCTION_STRING splitFilename(__FILE__) << "[" << std::dec <<  __LINE__ << "]:" << __FUNCTION__ << ":"


### PR DESCRIPTION
std::basic_string::find_last_of returns size_type, so use
size_t for pos to be arch independent.

Signed-off-by: Yegor Yefremov <yegorslists@googlemail.com>