### PR TITLE
Fix uninitialized read in SCTPThread::run

### DIFF
--- a/sctpthread.cpp
+++ b/sctpthread.cpp
@@ -209,7 +209,7 @@ void SCTPThread::run() {
       }
       if (FD_ISSET(m_socket, &readfds)) {
         struct sctp_sndrcvinfo sinfo;
-        int flags;
+        int flags = 0;
         bzero(&sinfo, sizeof(sinfo));
         /* Clear buffer */
         memset(buffer, 0, RECEIVE_BUFFER_SIZE);


### PR DESCRIPTION
The msg_flags parameter to sctp_recvmsg is actually an in/out parameter
: when the pointer is not null, the pointed-to value is used as the
flags for the initial recvmsg() call, and is set to the flags of the
received message before returning.

This leads to an uninitialized read, which is fixed by this commit.