### PR TITLE
Add -Wall switch and fix all warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 # Options
 option(SCTP_SUPPORT "SCTP_SUPPORT" ON)
 
+set(CMAKE_CXX_FLAGS -Wall)
+
 if(SCTP_SUPPORT)
   include(FindSCTP)
 else(SCTP_SUPPORT)

--- a/canthread.cpp
+++ b/canthread.cpp
@@ -42,10 +42,10 @@ CANThread::CANThread(const struct debugOptions_t &debugOptions,
                      const std::string &canInterfaceName = "can0")
   : ConnectionThread()
   , m_canSocket(0)
+  , m_canfd(false)
   , m_canInterfaceName(canInterfaceName)
   , m_rxCount(0)
   , m_txCount(0)
-  , m_canfd(false)
 {
   memcpy(&m_debugOptions, &debugOptions, sizeof(struct debugOptions_t));
 }
@@ -53,7 +53,6 @@ CANThread::CANThread(const struct debugOptions_t &debugOptions,
 CANThread::~CANThread() {}
 
 int CANThread::start() {
-  struct timeval timeout;
   struct ifreq canInterface;
   uint32_t canfd_on = 1;
   /* Setup our socket */
@@ -105,7 +104,6 @@ void CANThread::stop() {
 void CANThread::run() {
   fd_set readfds;
   ssize_t receivedBytes;
-  struct itimerspec ts;
 
   linfo << "CANThread up and running" << std::endl;
 

--- a/framebuffer.cpp
+++ b/framebuffer.cpp
@@ -25,10 +25,10 @@
 using namespace cannelloni;
 
 FrameBuffer::FrameBuffer(size_t size, size_t max) :
+  m_totalAllocCount(0),
   m_bufferSize(0),
   m_intermediateBufferSize(0),
-  m_maxAllocCount(max),
-  m_totalAllocCount(0)
+  m_maxAllocCount(max)
 {
   resizePool(size, false);
 }

--- a/udpthread.cpp
+++ b/udpthread.cpp
@@ -46,13 +46,13 @@ UDPThread::UDPThread(const struct debugOptions_t &debugOptions,
                      bool sort,
                      bool checkPeer)
   : ConnectionThread()
+  , m_sort(sort)
+  , m_checkPeer(checkPeer)
   , m_socket(0)
   , m_sequenceNumber(0)
   , m_timeout(100)
   , m_rxCount(0)
   , m_txCount(0)
-  , m_sort(sort)
-  , m_checkPeer(checkPeer)
   , m_payloadSize(UDP_PAYLOAD_SIZE)
 {
   memcpy(&m_debugOptions, &debugOptions, sizeof(struct debugOptions_t));
@@ -254,9 +254,6 @@ void UDPThread::prepareBuffer() {
   auto packetBuffer = bufWrap.get();
 
   ssize_t transmittedBytes = 0;
-
-
-  struct timeval currentTime;
 
   m_frameBuffer->swapBuffers();
   if (m_sort)


### PR DESCRIPTION
AOSP uses -Wall and -Werror switches by default. Current source code cannot be successfuly compiled because of that. This PR fixes all warnings.

Signed-off-by: Remigiusz Kołłątaj <remigiusz.kollataj@mobica.com>