### PR TITLE
Add TCP mode 🚀

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,10 +47,14 @@ add_library(addsources STATIC
             thread.cpp
             timer.cpp
             udpthread.cpp
+            tcpthread.cpp
+            tcp_client_thread.cpp
+            tcp_server_thread.cpp
             canthread.cpp)
 
 add_library(cannelloni-common SHARED
-            parser.cpp)
+            parser.cpp
+            decoder.cpp)
 
 set_target_properties ( cannelloni-common
   PROPERTIES

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Features:
 - easy debugging
 - CAN FD support on interfaces that support it
 - UDP support (fast, unreliable transport)
+- TCP support (reliable transport)
 - SCTP support (optional, reliable transport)
 
 # Important Usage Notice
@@ -107,6 +108,9 @@ what is wrong.
 
 ### Timeouts
 
+*UDP + SCTP only!*
+
+
 cannelloni either sends a full UDP frame or all CAN frames that
 are queued when the timeout that has been specified by the `-t` option
 has been reached.
@@ -198,6 +202,23 @@ If there is no remote IP supplied to the server instance, every client
 (any IP) will be accepted. Only one client can be connected at a time.
 After the client disconnects, the server waits for a new client.
 
+## TCP
+
+Usage example:
+
+IP: 192.168.0.2 (Server)
+```
+cannelloni -I vcan0 -C s
+```
+
+IP: 192.168.0.3 (Client)
+```
+cannelloni -I vcan0 -C c -R 192.168.0.2
+```
+
+With TCP, no frame buffer is used an frames are immediately transmitted,
+frame sorting and timeouts do not apply here.
+
 # Frame sorting
 
 CAN frames can be sorted by their ID in each ethernet frame to write
@@ -222,7 +243,7 @@ for your work.
 
 # License
 
-Copyright 2014-2019 Maximilian Güntner <code@mguentner.de>
+Copyright 2014-2023 Maximilian Güntner <code@mguentner.de>
 
 cannelloni is licensed under the GPL, version 2. See gpl-2.0.txt for
 more information.

--- a/decoder.cpp
+++ b/decoder.cpp
@@ -1,0 +1,94 @@
+/*
+ * This file is part of cannelloni, a SocketCAN over Ethernet tunnel.
+ *
+ * Copyright (C) 2014-2023 Maximilian Güntner <code@mguentner.de>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ */
+
+#include <cstring>
+#include <netinet/in.h>
+#include "decoder.h"
+#include "cannelloni.h"
+
+#define CAN_ID_SIZE_BYTES 4
+#define CAN_LEN_SIZE_BYTES 1
+#define CAN_FLAGS_SIZE_BYTES 1
+#define MAX_TRANSMIT_BUFFER_SIZE_BYTES CAN_ID_SIZE_BYTES + CAN_LEN_SIZE_BYTES + CAN_FLAGS_SIZE_BYTES + CANFD_MAX_DLEN
+
+using namespace cannelloni;
+
+ssize_t decodeFrame(uint8_t *data, size_t len, canfd_frame *frame, DecodeState *state) {
+  switch (*state) {
+  case STATE_INIT:
+    *state = STATE_CAN_ID;
+    return CAN_ID_SIZE_BYTES;
+  case STATE_CAN_ID:
+    if (len != CAN_ID_SIZE_BYTES) {
+      return -1;
+    }
+    canid_t tmp;
+    memcpy(&tmp, data, sizeof(canid_t));
+    frame->can_id = ntohl(tmp);
+    *state = STATE_LEN;
+    return CAN_LEN_SIZE_BYTES;
+  case STATE_LEN:
+    if (len != CAN_LEN_SIZE_BYTES) {
+      return -1;
+    }
+    frame->len = *data;
+    /* If this is a CAN FD frame, also retrieve the flags */
+    if (frame->len & CANFD_FRAME) {
+      *state = STATE_FLAGS;
+      return CAN_FLAGS_SIZE_BYTES;
+    }
+    /* RTR Frames have no data section although they have a dlc */
+    if (frame->can_id & CAN_RTR_FLAG) {
+      *state = STATE_INIT;
+      frame->len=0;
+      return 0;
+    }
+    if (canfd_len(frame) == 0) {
+      *state = STATE_INIT;
+      return 0;
+    }
+    *state = STATE_DATA;
+    return canfd_len(frame);
+  case STATE_FLAGS:
+    if (len != CAN_FLAGS_SIZE_BYTES) {
+      return -1;
+    }
+    frame->flags = *data;
+    /* RTR Frames have no data section although they have a dlc */
+    if (frame->can_id & CAN_RTR_FLAG) {
+      *state = STATE_INIT;
+      return 0;
+    }
+    if (canfd_len(frame) == 0) {
+      *state = STATE_INIT;
+      return 0;
+    }
+    *state = STATE_DATA;
+    return canfd_len(frame);
+  case STATE_DATA:
+    if (len != canfd_len(frame)) {
+      return -1;
+    }
+    memcpy(frame->data, data, canfd_len(frame));
+    *state = STATE_INIT;
+    return 0;
+  }
+  return -1;
+}

--- a/decoder.h
+++ b/decoder.h
@@ -1,0 +1,62 @@
+/*
+ * This file is part of cannelloni, a SocketCAN over Ethernet tunnel.
+ *
+ * Copyright (C) 2014-2023 Maximilian Güntner <code@mguentner.de>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <linux/can.h>
+#include <sys/types.h>
+
+#define CAN_ID_SIZE_BYTES 4
+#define CAN_LEN_SIZE_BYTES 1
+#define CAN_FLAGS_SIZE_BYTES 1
+#define MAX_TRANSMIT_BUFFER_SIZE_BYTES CAN_ID_SIZE_BYTES + CAN_LEN_SIZE_BYTES + CAN_FLAGS_SIZE_BYTES + CANFD_MAX_DLEN
+
+enum DecodeState {
+  STATE_INIT,
+  STATE_CAN_ID,
+  STATE_LEN,
+  STATE_FLAGS,
+  STATE_DATA,
+};
+
+struct Decoder {
+  canfd_frame tempFrame;
+  ssize_t expectedBytes;
+  DecodeState state;
+
+  Decoder() { reset(); }
+
+  void reset() {
+    expectedBytes = 0;
+    state = STATE_INIT;
+  }
+};
+
+/**
+ * Decodes a CAN frame from input data.
+ *
+ * @param data Pointer to the input data to be decoded.
+ * @param len The length of the input data in bytes.
+ * @param frame Pointer to the CAN frame structure where the decoded frame will be stored.
+ * @param state Pointer to a variable that tracks the state of the decoding process.
+ * @return On success, the number of bytes remaining to be read after decoding the current segment of the frame. On error, a negative value indicating the error. If the decoding process completes successfully, this function will return 0. `frame` will then contain all decoded data.
+ */
+ssize_t decodeFrame(uint8_t *data, size_t len, canfd_frame *frame, DecodeState *state);

--- a/doc/tcp_protocol.md
+++ b/doc/tcp_protocol.md
@@ -1,0 +1,31 @@
+# cannelloni TCP Protocol version 1
+
+After connecting, each peer is expected to send the string `"CANNELLONIv1"`, without a terminator (`\0`).
+
+Then frames are send in both directions in binary encoding. The structure is similar to the UDP / SCTP
+protocol:
+
+| Bytes |  Name   |   Description       |
+|-------|---------|---------------------|
+|   4   |  can_id |  see `<linux/can.h>`|
+|   1   |  len    |  size of payload/dlc|
+|   1   |  flags^ |  CAN FD flags       |
+|0-8/64 |  data   |  Data section       |
+
+^ = CAN FD only
+
+Everything is Big-Endian/Network Byte Order.
+
+There is no delimiter, after the last byte of the first frame, the next frame's can_id is expected.
+Be aware that a frame might be complete after just the `len` information. You can check `decoder.cpp`
+for a state-machine based decoder for streams and `parser.cpp` for a general code to encode
+frames.
+
+## CAN FD
+
+CAN FD frames are marked with the MSB of `len` being
+set, so `len | (0x80)`. If this bit is set, the `flags`
+attribute is inserted between `len` and `data`.
+For CAN 2.0 frames this attribute is missing.
+`data` can be 0-8 Bytes long for CAN 2.0 and 0-64 Bytes
+for CAN FD frames.

--- a/doc/udp_format.md
+++ b/doc/udp_format.md
@@ -1,6 +1,6 @@
-#cannelloni UDP/SCTP Format version 2
+# cannelloni UDP/SCTP Format version 2
 
-##Data Frames
+## Data Frames
 
 Each data frame can contain several CAN frames.
 
@@ -32,7 +32,7 @@ Everything is Big-Endian/Network Byte Order.
 
 *The frame format is identical for UDP and SCTP*
 
-##CAN FD
+## CAN FD
 
 CAN FD frames are marked with the MSB of `len` being
 set, so `len | (0x80)`. If this bit is set, the `flags`

--- a/framebuffer.cpp
+++ b/framebuffer.cpp
@@ -220,13 +220,9 @@ void FrameBuffer::clearPool() {
   std::unique_lock<std::recursive_mutex> lock3(m_intermediateBufferMutex, std::defer_lock);
   std::lock(lock1, lock2, lock3);
 
+  reset();
+
   for (canfd_frame *f : m_framePool) {
-    delete f;
-  }
-  for (canfd_frame *f : m_intermediateBuffer) {
-    delete f;
-  }
-  for (canfd_frame *f : m_buffer) {
     delete f;
   }
   m_framePool.clear();

--- a/parser.h
+++ b/parser.h
@@ -4,6 +4,7 @@
 #include "cannelloni.h"
 
 #include <linux/can.h>
+#include <sys/types.h>
 
 #include <functional>
 #include <list>
@@ -31,18 +32,31 @@ void parseFrames(uint16_t len, const uint8_t* buffer,
         std::function<void(canfd_frame*, bool)> frameReceiver);
 
 /**
+ * Encodes a CAN frame into its binary data format.
+ *
+ * @param data Pointer to the data buffer where the encoded frame will be
+ stored.
+ * @param frame Pointer to the CAN frame structure to encode.
+ *
+ * @return The size of the encoded frame.
+ */
+size_t encodeFrame(uint8_t *data, canfd_frame *frame);
+
+/**
  * Builds Cannelloni packet from provided list of CAN frames
  * @param len Buffer length
  * @param packetBuffer Pointer to buffer that will contain Cannelloni packet
  * @param frames Reference to list of pointers to CAN frames
  * @param seqNo Packet sequence number
- * @param handleOverflow Callback responsible for handling CAN frames that did't fit
- *  into Cannelloni package. First argument is a frames list reference, second argument
- *  is iterator to the first not handled frame.
+ * @param handleOverflow Callback responsible for handling CAN frames that
+ * did't fit into Cannelloni package. First argument is a frames list
+ * reference, second argument is iterator to the first not handled frame.
  * @return
  */
-uint8_t* buildPacket(uint16_t len, uint8_t* packetBuffer,
-        std::list<canfd_frame*>& frames, uint8_t seqNo,
-        std::function<void(std::list<canfd_frame*>&, std::list<canfd_frame*>::iterator)> handleOverflow);
+uint8_t *buildPacket(uint16_t len, uint8_t *packetBuffer,
+                         std::list<canfd_frame *> &frames, uint8_t seqNo,
+                         std::function<void(std::list<canfd_frame *> &,
+                                            std::list<canfd_frame *>::iterator)>
+                             handleOverflow);
 
 #endif /* PARSER_H_ */

--- a/sctpthread.cpp
+++ b/sctpthread.cpp
@@ -64,7 +64,7 @@ int SCTPThread::start() {
    * one-to-many connections, we can also use SOCK_STREAM
    * instead of SOCK_SEQPACKET
    */
-  if (m_role == SERVER) {
+  if (m_role == SCTP_SERVER) {
     m_serverSocket = socket(AF_INET, SOCK_STREAM, IPPROTO_SCTP);
     if (m_serverSocket < 0) {
       lerror << "socket error" << std::endl;
@@ -97,7 +97,7 @@ void SCTPThread::run() {
 
   while (m_started) {
     if (!m_connected) {
-      if (m_role == SERVER) {
+      if (m_role == SCTP_SERVER) {
         struct sockaddr_in connAddr;
         char connAddrStr[INET_ADDRSTRLEN];
         socklen_t connAddrLen = sizeof(connAddr);
@@ -146,9 +146,8 @@ void SCTPThread::run() {
             std::this_thread::sleep_for(std::chrono::seconds(2));
             continue;
           }
-        } else {
-          linfo << "Got a connection from " << connAddrStr << std::endl;
         }
+        linfo << "Got a connection from " << connAddrStr << std::endl;
         /* At this point we have a valid connection */
         m_connected = true;
         /* Clear the old entries in frameBuffer */
@@ -237,7 +236,7 @@ void SCTPThread::run() {
   linfo << "Shutting down. SCTP Transmission Summary: TX: " << m_txCount << " RX: " << m_rxCount << std::endl;
   m_connected = false;
   close(m_socket);
-  if (m_role == SERVER) {
+  if (m_role == SCTP_SERVER) {
     close(m_serverSocket);
   }
 }

--- a/sctpthread.h
+++ b/sctpthread.h
@@ -29,7 +29,7 @@ namespace cannelloni {
 #define SCTP_HEADER_SIZE 12
 #define SCTP_PAYLOAD_SIZE ETHERNET_MTU-IP_HEADER_SIZE-SCTP_HEADER_SIZE
 
-enum SCTPThreadRole {SERVER, CLIENT};
+enum SCTPThreadRole {SCTP_SERVER, SCTP_CLIENT};
 
 class SCTPThread : public UDPThread {
   public:

--- a/tcp_client_thread.cpp
+++ b/tcp_client_thread.cpp
@@ -1,0 +1,59 @@
+/*
+ * This file is part of cannelloni, a SocketCAN over Ethernet tunnel.
+ *
+ * Copyright (C) 2014-2023 Maximilian Güntner <code@mguentner.de>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ */
+
+#include "logging.h"
+#include "tcpthread.h"
+#include <arpa/inet.h>
+#include <cstring>
+#include <unistd.h>
+
+using namespace cannelloni;
+
+TCPClientThread::TCPClientThread(const struct debugOptions_t &debugOptions,
+                                 const struct sockaddr_in &remoteAddr,
+                                 const struct sockaddr_in &localAddr)
+  : TCPThread(debugOptions, remoteAddr, localAddr)
+{
+}
+
+bool TCPClientThread::attempt_connect() {
+  m_socket = socket(AF_INET, SOCK_STREAM, 0);
+  if (m_socket < 0) {
+    lerror << "socket error" << std::endl;
+    return false;
+  }
+  if (!setupSocket()) {
+    return false;
+  }
+  if (!setupPipe()) {
+    return false;
+  }
+  linfo << "Connecting to " << inet_ntoa(m_remoteAddr.sin_addr) << ":"
+        << ntohs(m_remoteAddr.sin_port) << "..." << std::endl;
+  if (connect(m_socket, (struct sockaddr *)&m_remoteAddr, sizeof(m_remoteAddr)) < 0) {
+    close(m_socket);
+    linfo << "Connect failed." << std::endl;
+    return false;
+  }
+  linfo << "Connected!" << std::endl;
+  return true;
+}
+
+void TCPClientThread::cleanup() {}

--- a/tcp_server_thread.cpp
+++ b/tcp_server_thread.cpp
@@ -1,0 +1,118 @@
+/*
+ * This file is part of cannelloni, a SocketCAN over Ethernet tunnel.
+ *
+ * Copyright (C) 2014-2023 Maximilian Güntner <code@mguentner.de>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ */
+
+#include "logging.h"
+#include "tcpthread.h"
+#include <arpa/inet.h>
+#include <cstring>
+#include <unistd.h>
+
+using namespace cannelloni;
+
+TCPServerThread::TCPServerThread(const struct debugOptions_t &debugOptions,
+                                 const struct sockaddr_in &remoteAddr,
+                                 const struct sockaddr_in &localAddr,
+                                 bool checkPeer)
+  : TCPThread(debugOptions, remoteAddr, localAddr),
+  m_checkPeerConnect(checkPeer)
+{
+
+}
+
+int TCPServerThread::start() {
+  m_serverSocket = socket(AF_INET, SOCK_STREAM, 0);
+  if (m_serverSocket < 0) {
+    lerror << "socket error" << std::endl;
+    return -1;
+  }
+
+  const int option = 1;
+  setsockopt(m_serverSocket, SOL_SOCKET, SO_REUSEADDR, &option, sizeof(option));
+
+  if (bind(m_serverSocket, (struct sockaddr *)&m_localAddr,
+           sizeof(m_localAddr)) < 0) {
+    lerror << "Could not bind to address" << std::endl;
+    return -1;
+  }
+  return TCPThread::start();
+}
+
+bool TCPServerThread::attempt_connect() {
+  struct sockaddr_in connAddr;
+  char connAddrStr[INET_ADDRSTRLEN];
+  socklen_t connAddrLen = sizeof(connAddr);
+  fd_set readfds;
+  struct timeval timeout;
+
+  listen(m_serverSocket, 1);
+  FD_ZERO(&readfds);
+  FD_SET(m_serverSocket, &readfds);
+
+  linfo << "Waiting for a client to connect." << std::endl;
+  /* Set Timeout to 1 second */
+  timeout.tv_sec = 1;
+  timeout.tv_usec = 0;
+  int ret = select(m_serverSocket+1, &readfds, NULL, NULL, &timeout);
+  if (ret < 0) {
+    lerror << "select error" << std::endl;
+    return false;
+  } else if (ret == 0) {
+    /* Timeout occurred, checking whether m_started changed */
+    return false;
+  } /* else */
+  m_socket = accept(m_serverSocket,(struct sockaddr*) &connAddr, &connAddrLen);
+  /* Reject all further connection attempts */
+  listen(m_serverSocket, 0);
+  if (m_socket == -1) {
+    lerror << "Error while accepting." << std::endl;
+    return false;
+  }
+  if (inet_ntop(AF_INET, &connAddr.sin_addr, connAddrStr, INET_ADDRSTRLEN) == NULL) {
+    lwarn << "Could not convert client address" << std::endl;
+    close(m_socket);
+    return false;
+  }
+  /*
+   * We have a connection, now check whether it matches the one
+   * the user specified as the peer unless m_checkPeerConnect is false
+   */
+  if (m_checkPeerConnect) {
+    if (memcmp(&(connAddr.sin_addr), &(m_remoteAddr.sin_addr), sizeof(struct in_addr)) != 0) {
+      lwarn << "Got a connection from " << connAddrStr
+            << ", which is not set as a remote." << std::endl;
+      close(m_socket);
+      return false;
+    }
+  }
+  linfo << "Got a connection from " << connAddrStr << std::endl;
+  /* Clear the old entries in frameBuffer */
+  m_frameBuffer->reset();
+  m_decoder.reset();
+  /* At this point we have a valid connection */
+  if (!setupSocket()) {
+    return false;
+  }
+  if (!setupPipe()) {
+    return false;
+  }
+  return true;
+}
+
+void TCPServerThread::cleanup() { close(m_serverSocket); }

--- a/tcpthread.cpp
+++ b/tcpthread.cpp
@@ -1,0 +1,275 @@
+/*
+ * This file is part of cannelloni, a SocketCAN over Ethernet tunnel.
+ *
+ * Copyright (C) 2014-2023 Maximilian Güntner <code@mguentner.de>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ */
+
+#include <algorithm>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+
+#include <bits/stdc++.h>
+
+#include <linux/can.h>
+#include <string.h>
+
+#include <fcntl.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <errno.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/ioctl.h>
+#include <sys/select.h>
+#include <sys/timerfd.h>
+
+
+#include <net/if.h>
+#include <arpa/inet.h>
+
+#include <netinet/tcp.h>
+
+#include "cannelloni.h"
+#include "connection.h"
+#include "logging.h"
+#include "parser.h"
+#include "tcpthread.h"
+
+TCPThread::TCPThread(const struct debugOptions_t &debugOptions,
+                       const struct sockaddr_in &remoteAddr,
+                     const struct sockaddr_in &localAddr)
+   : ConnectionThread()
+  , m_debugOptions(debugOptions)
+  , m_serverSocket(0)
+  , m_socket(0)
+  , m_connect_state(DISCONNECTED)
+  , m_rxCount(0)
+  , m_txCount(0)
+{
+
+  memcpy(&m_remoteAddr, &remoteAddr, sizeof(struct sockaddr_in));
+  memcpy(&m_localAddr, &localAddr, sizeof(struct sockaddr_in));
+}
+
+int TCPThread::start() {
+  return Thread::start();
+}
+
+
+
+void TCPThread::run() {
+  fd_set readfds;
+  uint8_t buffer[MAX_TRANSMIT_BUFFER_SIZE_BYTES];
+  uint8_t protocolVersionBuffer[] = CANNELLONI_CONNECT_V1_STRING;
+
+  /* Set interval to m_timeout */
+  m_blockTimer.adjust(SELECT_TIMEOUT, SELECT_TIMEOUT);
+
+  while (m_started) {
+    if (m_connect_state == DISCONNECTED) {
+      bool connect_successful = attempt_connect();
+      if (connect_successful) {
+        m_connect_state = CONNECTED;
+        ssize_t res = write(m_socket, protocolVersionBuffer, sizeof(protocolVersionBuffer)-1);
+        if (res != sizeof(protocolVersionBuffer)-1) {
+          lerror << "write error could not announce protocol" << std::endl;
+          disconnect();
+          continue;
+        }
+      } else {
+        /* Wait here for some time until the next attempt */
+        std::this_thread::sleep_for(std::chrono::seconds(2));
+      }
+    } else {
+      /* Prepare readfds */
+      FD_ZERO(&readfds);
+      FD_SET(m_socket, &readfds);
+      FD_SET(m_blockTimer.getFd(), &readfds);
+      FD_SET(m_framebufferHasDataPipe[SIGNAL_PIPE_READ], &readfds);
+      int ret = select(std::max({m_socket, m_blockTimer.getFd(), m_framebufferHasDataPipe[SIGNAL_PIPE_READ]})+1, &readfds, NULL, NULL, NULL);
+      if (ret < 0) {
+        if (errno == EOF) {
+          disconnect();
+        }
+        /* Check whether the remote has terminated the connection */
+        lerror << "select error" << std::endl;
+        continue;
+      }
+      if (FD_ISSET(m_blockTimer.getFd(), &readfds)) {
+        m_blockTimer.read();
+        /*
+           Let's flush out the frame buffer as well as there might be single frames left
+           that have not been signaled through the pipe due to blocking
+        */
+        flushFrameBuffer();
+      }
+      if (FD_ISSET(m_framebufferHasDataPipe[SIGNAL_PIPE_READ], &readfds)) {
+        int signal;
+        ssize_t res = read(m_framebufferHasDataPipe[SIGNAL_PIPE_READ], &signal, sizeof(signal));
+        if (res == sizeof(signal)) {
+          flushFrameBuffer();
+        }
+      }
+      if (FD_ISSET(m_socket, &readfds)) {
+        ssize_t receivedBytes = 0;
+        ssize_t expectedBytes = 0;
+        if (m_connect_state == CONNECTED) {
+          expectedBytes = sizeof(CANNELLONI_CONNECT_V1_STRING)-1;
+        } else {
+          expectedBytes = m_decoder.expectedBytes;
+        }
+        if (expectedBytes != 0) {
+          /* check whether we can read enough bytes */
+          int available;
+          if (ioctl(m_socket, FIONREAD, &available) == -1) {
+            lerror << "ioctl failed" << std::endl;
+            disconnect();
+            continue;
+          } else if (available > 0 && available < static_cast<int>(expectedBytes)) {
+            /* not enough bytes are available, let's wait a bit */
+            std::this_thread::sleep_for(std::chrono::milliseconds(20));
+            continue;
+          }
+
+          receivedBytes = read(m_socket, buffer, expectedBytes);
+          if (receivedBytes < 0) {
+            lerror << "recvfrom error." << std::endl;
+            /* close connection */
+            disconnect();
+            continue;
+          } else if (receivedBytes == 0){
+            disconnect();
+            continue;
+          }
+        }
+        if (m_connect_state == CONNECTED) {
+          if (memcmp(buffer, protocolVersionBuffer, sizeof(CANNELLONI_CONNECT_V1_STRING)-1) == 0) {
+            m_connect_state = NEGOTIATED;
+            continue;
+          } else {
+            lwarn << "Invalid protocol detected" << std::endl;
+            disconnect();
+            continue;
+          }
+        } else {
+          m_decoder.expectedBytes = decodeFrame(buffer, receivedBytes, &m_decoder.tempFrame, &m_decoder.state);
+          if (m_decoder.expectedBytes == 0) {
+            canfd_frame *frameBufferFrame = m_peerThread->getFrameBuffer()->requestFrame(true, m_debugOptions.buffer);
+            if (frameBufferFrame != NULL) {
+              memcpy(frameBufferFrame, &m_decoder.tempFrame, sizeof(m_decoder.tempFrame));
+              m_peerThread->transmitFrame(frameBufferFrame);
+            } else {
+              lerror << "Dropping frame due to framebuffer issue." << std::endl;
+            }
+            m_rxCount++;
+            continue;
+          } else if (m_decoder.expectedBytes == -1) {
+            lerror << "Decoder Error" << std::endl;
+            disconnect();
+            continue;
+          }
+        }
+      }
+    }
+  }
+  if (m_debugOptions.buffer) {
+    m_frameBuffer->debug();
+  }
+  linfo << "Shutting down. TCP Transmission Summary: TX: " << m_txCount << " RX: " << m_rxCount << std::endl;
+  m_connect_state = DISCONNECTED;
+  close(m_socket);
+  cleanup();
+}
+
+void TCPThread::disconnect() {
+  m_connect_state = DISCONNECTED;
+  close(m_socket);
+  close(m_framebufferHasDataPipe[SIGNAL_PIPE_READ]);
+  close(m_framebufferHasDataPipe[SIGNAL_PIPE_WRITE]);
+}
+
+void TCPThread::transmitFrame(canfd_frame *frame) {
+  if (m_connect_state != NEGOTIATED) {
+    m_frameBuffer->insertFramePool(frame);
+    return;
+  }
+  m_frameBuffer->insertFrame(frame);
+  int signal = 1;
+  ssize_t res = write(m_framebufferHasDataPipe[SIGNAL_PIPE_WRITE], &signal, sizeof(signal));
+  if (res != sizeof(signal)) {
+    /*
+       when writing a lot of frames, the main loop might be too slow to consume the signals
+       from the pipe which is not an error
+    */
+    if (errno != EWOULDBLOCK) {
+      lwarn << "could not write to pipe " << res << std::endl;
+    }
+  }
+  return;
+}
+
+void TCPThread::flushFrameBuffer() {
+  if (m_connect_state != NEGOTIATED) {
+    return;
+  }
+  uint8_t transmitBuffer[MAX_TRANSMIT_BUFFER_SIZE_BYTES];
+  m_frameBuffer->swapBuffers();
+  std::list<canfd_frame*> *frames = m_frameBuffer->getIntermediateBuffer();
+  for (auto it = frames->begin(); it != frames->end(); it++) {
+    canfd_frame* frame = *it;
+    ssize_t encodedBytes = encodeFrame(transmitBuffer, frame);
+    ssize_t bytesWritten = send(m_socket, transmitBuffer, encodedBytes, 0);
+    if (encodedBytes != bytesWritten) {
+      disconnect();
+      break;
+    }
+    m_txCount++;
+  }
+  m_frameBuffer->unlockIntermediateBuffer();
+  m_frameBuffer->mergeIntermediateBuffer();
+}
+
+bool TCPThread::setupSocket() {
+  const int nagle = 0;
+  const int min_window_size = 1;
+  if (setsockopt(m_socket, IPPROTO_TCP, TCP_WINDOW_CLAMP, &min_window_size, sizeof(min_window_size))) {
+    lerror << "Could not set window size to " << min_window_size << std::endl;
+    return false;
+  }
+  /* Disable Nagle for this connection */
+  if (setsockopt(m_socket, IPPROTO_TCP, TCP_NODELAY, &nagle, sizeof(nagle))) {
+    lerror << "Could not disable Nagle." << std::endl;
+    return false;
+  }
+  return true;
+}
+
+bool TCPThread::setupPipe() {
+  if (pipe(m_framebufferHasDataPipe) == -1) {
+    lerror << "could not inititalize signal pipe" << std::endl;
+    return false;
+  }
+  if (fcntl(m_framebufferHasDataPipe[SIGNAL_PIPE_WRITE], F_SETFL, O_NONBLOCK) <
+      0) {
+    lerror << "could not inititalize signal pipe" << std::endl;
+    return false;
+  }
+  return true;
+}

--- a/tcpthread.h
+++ b/tcpthread.h
@@ -1,0 +1,106 @@
+/*
+ * This file is part of cannelloni, a SocketCAN over Ethernet tunnel.
+ *
+ * Copyright (C) 2014-2023 Maximilian Güntner <code@mguentner.de>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ */
+
+#pragma once
+
+#include "connection.h"
+#include "timer.h"
+#include "decoder.h"
+#include <mutex>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+
+#define SELECT_TIMEOUT 500000
+#define SIGNAL_PIPE_READ 0
+#define SIGNAL_PIPE_WRITE 1
+
+enum TCPThreadRole { TCP_SERVER, TCP_CLIENT };
+/*
+  DISCONNECTED: Waiting for a connection
+  CONNECTED: TCP Connection established
+  NEGOTIATED: A cannelloni peer has been found
+ */
+enum ConnectState { DISCONNECTED, CONNECTED, NEGOTIATED };
+
+#define CANNELLONI_CONNECT_V1_STRING "CANNELLONIv1"
+
+namespace cannelloni {
+
+  class TCPThread : public ConnectionThread {
+    public:
+      TCPThread(const struct debugOptions_t &debugOptions,
+                 const struct sockaddr_in &remoteAddr,
+                 const struct sockaddr_in &localAddr);
+
+      virtual int start();
+      virtual void cleanup() = 0;
+      virtual void run();
+
+      virtual void transmitFrame(canfd_frame *frame);
+
+    protected:
+      bool isConnected();
+      void flushFrameBuffer();
+      void disconnect();
+      bool setupSocket();
+      bool setupPipe();
+      virtual bool attempt_connect() = 0;
+
+    protected:
+      struct debugOptions_t m_debugOptions;
+      int m_serverSocket;
+      int m_socket;
+      ConnectState m_connect_state;
+      Timer m_blockTimer;
+      uint64_t m_rxCount;
+      uint64_t m_txCount;
+      std::recursive_mutex m_socketWriteMutex;
+
+      struct sockaddr_in m_localAddr;
+      struct sockaddr_in m_remoteAddr;
+
+      int m_framebufferHasDataPipe[2];
+      Decoder m_decoder;
+  };
+
+  class TCPServerThread : public TCPThread  {
+    public:
+      TCPServerThread(const struct debugOptions_t &debugOptions,
+                      const struct sockaddr_in &remoteAddr,
+                      const struct sockaddr_in &localAddr,
+                      bool checkPeer);
+
+      virtual int start();
+      virtual bool attempt_connect();
+      virtual void cleanup();
+
+    private:
+      bool m_checkPeerConnect;
+  };
+
+  class TCPClientThread : public TCPThread {
+  public:
+    TCPClientThread(const struct debugOptions_t &debugOptions,
+                    const struct sockaddr_in &remoteAddr,
+                    const struct sockaddr_in &localAddr);
+    virtual bool attempt_connect();
+    virtual void cleanup();
+  };
+}


### PR DESCRIPTION
Hello everybody,

I have finally found some time to work on adding TCP support for cannelloni (see also #20). This PR is a replacement of #38, and I would like to thank @simontegelid for their initial work!

With the extension of a decoder designed for streams, cannelloni can now support packet-oriented transports like TCP. Similar to the UDP protocol, the design is kept simple and straightforward. The protocol is binary and does not have any delimiters, and messages are sent one after the other. Since the CAN frame type provides enough information to know how many bytes need to be read, an additional data length code is not necessary.

The only addition to the protocol is a mandatory string that is sent upon connection establishment, which is currently set to `CANNELLONIv1`. This string allows instances to negotiate protocols, reject non-cannelloni peers (think `nmap`), and can be easily implemented on any hardware/software stack that is capable of communicating via TCP.

The key difference between the UDP/SCTP packet-based protocol and the TCP implementation is that frames are sent out immediately without buffering or sorting. Enabling these options will have no effect, and it might be good to throw an error if the user attempts to do so. The memory footprint can be improved in the future by reducing the `FrameBuffer` to just a few frames for passing between `CANThread` and `TCPThread` and vice versa.

In addition to adding TCP support, there has been some refactoring. For example, the main thread now has a pointer to `ConnectionThread` instead of an `UDPThread` since `TCPThread` does not inherit from `UDPThread`.

I will leave this PR open for 10 days (until March 23, 2023) so that people have time to comment.

pinging @jreppnow as you might be interested in participating in the discussion :eyes: 