### PR TITLE
feat: add ipv6 support

### DIFF
--- a/canthread.cpp
+++ b/canthread.cpp
@@ -38,8 +38,7 @@
 
 using namespace cannelloni;
 
-CANThread::CANThread(const struct debugOptions_t &debugOptions,
-                     const std::string &canInterfaceName = "can0")
+CANThread::CANThread(const struct debugOptions_t &debugOptions, const std::string &canInterfaceName)
   : ConnectionThread()
   , m_canSocket(0)
   , m_canfd(false)
@@ -62,7 +61,7 @@ int CANThread::start() {
     return -1;
   }
   /* Determine the index of m_canInterfaceName */
-  strcpy(canInterface.ifr_name, m_canInterfaceName.c_str());
+  strncpy(canInterface.ifr_name, m_canInterfaceName.c_str(), IFNAMSIZ);
   if (ioctl(m_canSocket, SIOCGIFINDEX, &canInterface) < 0) {
     lerror << "Could get index of interface >" << m_canInterfaceName << "<" << std::endl;
     return -1;

--- a/inet_address.cpp
+++ b/inet_address.cpp
@@ -6,18 +6,35 @@
 #include <iostream>
 #include <netdb.h>
 #include <netinet/in.h>
+#include <sys/socket.h>
 
-bool parseAddress(const char *address_str, struct sockaddr_in &sock_addr) {
-  // Try parsing as IPv4 address
-  if (inet_pton(AF_INET, address_str, &(sock_addr.sin_addr)) == 1) {
-    sock_addr.sin_family = AF_INET;
-    return true;
+bool parseAddress(const char *address_str, struct sockaddr *sock_addr, int addr_family = AF_INET) {
+  if (address_str == NULL) {
+    lerror << "address_str is NULL" << std::endl;
+    return false;
+  }
+  // Try parsing as IPv4 / IPv6 address
+  if (addr_family == AF_INET)  {
+    struct sockaddr_in *addr = (struct sockaddr_in *)  sock_addr;
+    if (inet_pton(addr_family, address_str, &addr->sin_addr) == 1) {
+      addr->sin_family = AF_INET;
+      return true;
+    }
+  } else if (addr_family == AF_INET6) {
+    struct sockaddr_in6 *addr = (struct sockaddr_in6 *)  sock_addr;
+    if (inet_pton(addr_family, address_str, &addr->sin6_addr) == 1) {
+      addr->sin6_family = AF_INET6;
+      return true;
+    }
+  } else {
+    // unsupported addr_family, unlikely to happen
+    return false;
   }
 
   // Resolve as DNS A/AAAA record
-  struct addrinfo hints, *result;
+  struct addrinfo hints, *result, *p;
   std::memset(&hints, 0, sizeof(hints));
-  hints.ai_family = AF_INET;
+  hints.ai_family = addr_family;
 
   int status = getaddrinfo(address_str, nullptr, &hints, &result);
   if (status != 0) {
@@ -25,14 +42,54 @@ bool parseAddress(const char *address_str, struct sockaddr_in &sock_addr) {
     return false;
   }
 
-  // Use the first resolved address
-  if (result->ai_family == AF_INET) {
-    std::memcpy(&sock_addr, result->ai_addr, result->ai_addrlen);
-    freeaddrinfo(result);
-    return true;
-  } else {
-    lerror << "Invalid address family" << std::endl;
-    freeaddrinfo(result);
-    return false;
+  bool success = false;
+  for (p = result; p != NULL; p = p->ai_next) {
+    if (p->ai_family == addr_family) {
+      std::memcpy(sock_addr, p->ai_addr, p->ai_addrlen);
+      success = true;
+      break;
+    }
+    // else: Invalid address family
   }
+  freeaddrinfo(result);
+  return success;
+}
+
+SocketStringAddress getSocketAddress(const struct sockaddr_storage* addr) {
+    SocketStringAddress socketAddress;
+    char ipString[INET6_ADDRSTRLEN];
+
+    if (addr->ss_family == AF_INET) {
+        const struct sockaddr_in* ipv4 = (const struct sockaddr_in*)addr;
+        inet_ntop(AF_INET, &(ipv4->sin_addr), ipString, INET_ADDRSTRLEN);
+        socketAddress.port = ntohs(ipv4->sin_port);
+        socketAddress.addressFamily = AF_INET;
+    } else if (addr->ss_family == AF_INET6) {
+        const struct sockaddr_in6* ipv6 = (const struct sockaddr_in6*)addr;
+        inet_ntop(AF_INET6, &(ipv6->sin6_addr), ipString, INET6_ADDRSTRLEN);
+        socketAddress.port = ntohs(ipv6->sin6_port);
+        socketAddress.addressFamily = AF_INET6;
+    } else {
+        socketAddress.port = 0;
+        socketAddress.ipAddress = "Unsupported address family";
+        socketAddress.addressFamily = AF_UNSPEC;
+        return socketAddress;
+    }
+    socketAddress.ipAddress = std::string(ipString);
+    return socketAddress;
+}
+
+
+std::string formatSocketAddress(const SocketStringAddress& socketAddress) {
+    std::string formattedAddress;
+
+    if (socketAddress.addressFamily == AF_INET6) {
+        formattedAddress = "[" + socketAddress.ipAddress + "]";
+    } else {
+        formattedAddress = socketAddress.ipAddress;
+    }
+
+    formattedAddress += ":" + std::to_string(socketAddress.port);
+
+    return formattedAddress;
 }

--- a/inet_address.h
+++ b/inet_address.h
@@ -1,4 +1,15 @@
 #pragma once
 #include <arpa/inet.h>
+#include <cstdint>
+#include <string>
 
-bool parseAddress(const char *address_str, struct sockaddr_in &sock_addr);
+struct SocketStringAddress {
+    std::string ipAddress;
+    uint16_t port;
+    uint8_t addressFamily;
+};
+
+bool parseAddress(const char *address_str, struct sockaddr *sock_addr, int addr_family);
+
+SocketStringAddress getSocketAddress(const struct sockaddr_storage* addr);
+std::string formatSocketAddress(const SocketStringAddress& socketAddress);

--- a/sctpthread.h
+++ b/sctpthread.h
@@ -22,6 +22,7 @@
 
 #include "udpthread.h"
 #include <netinet/sctp.h>
+#include <sys/socket.h>
 
 namespace cannelloni {
 
@@ -34,8 +35,9 @@ enum SCTPThreadRole {SCTP_SERVER, SCTP_CLIENT};
 class SCTPThread : public UDPThread {
   public:
     SCTPThread(const struct debugOptions_t &debugOptions,
-               const struct sockaddr_in &remoteAddr,
-               const struct sockaddr_in &localAddr,
+               const struct sockaddr_storage &remoteAddr,
+               const struct sockaddr_storage &localAddr,
+               int address_family,
                bool sort,
                bool checkPeer,
                SCTPThreadRole role);
@@ -51,11 +53,11 @@ class SCTPThread : public UDPThread {
     bool isConnected();
 
   private:
-    bool m_checkPeerConnect;
-    int m_serverSocket;
     sctp_assoc_t m_assoc_id;
-    bool m_connected;
     SCTPThreadRole m_role;
+    bool m_checkPeerConnect;
+    bool m_connected;
+    int m_serverSocket;
 };
 
 }

--- a/tcpthread.cpp
+++ b/tcpthread.cpp
@@ -53,8 +53,9 @@
 #include "tcpthread.h"
 
 TCPThread::TCPThread(const struct debugOptions_t &debugOptions,
-                       const struct sockaddr_in &remoteAddr,
-                     const struct sockaddr_in &localAddr)
+                     const struct sockaddr_storage &remoteAddr,
+                     const struct sockaddr_storage &localAddr,
+                     int address_family)
    : ConnectionThread()
   , m_debugOptions(debugOptions)
   , m_serverSocket(0)
@@ -62,10 +63,11 @@ TCPThread::TCPThread(const struct debugOptions_t &debugOptions,
   , m_connect_state(DISCONNECTED)
   , m_rxCount(0)
   , m_txCount(0)
+  , m_address_family(address_family)
 {
 
-  memcpy(&m_remoteAddr, &remoteAddr, sizeof(struct sockaddr_in));
-  memcpy(&m_localAddr, &localAddr, sizeof(struct sockaddr_in));
+  memcpy(&m_remoteAddr, &remoteAddr, sizeof(struct sockaddr_storage));
+  memcpy(&m_localAddr, &localAddr, sizeof(struct sockaddr_storage));
 }
 
 int TCPThread::start() {

--- a/tcpthread.h
+++ b/tcpthread.h
@@ -26,6 +26,7 @@
 #include <mutex>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
+#include <sys/socket.h>
 
 #define SELECT_TIMEOUT 500000
 #define SIGNAL_PIPE_READ 0
@@ -46,8 +47,9 @@ namespace cannelloni {
   class TCPThread : public ConnectionThread {
     public:
       TCPThread(const struct debugOptions_t &debugOptions,
-                 const struct sockaddr_in &remoteAddr,
-                 const struct sockaddr_in &localAddr);
+                 const struct sockaddr_storage &remoteAddr,
+                 const struct sockaddr_storage &localAddr,
+                 int address_family);
 
       virtual int start();
       virtual void cleanup() = 0;
@@ -73,8 +75,9 @@ namespace cannelloni {
       uint64_t m_txCount;
       std::recursive_mutex m_socketWriteMutex;
 
-      struct sockaddr_in m_localAddr;
-      struct sockaddr_in m_remoteAddr;
+      struct sockaddr_storage m_localAddr;
+      struct sockaddr_storage m_remoteAddr;
+      int m_address_family;
 
       int m_framebufferHasDataPipe[2];
       Decoder m_decoder;
@@ -83,8 +86,9 @@ namespace cannelloni {
   class TCPServerThread : public TCPThread  {
     public:
       TCPServerThread(const struct debugOptions_t &debugOptions,
-                      const struct sockaddr_in &remoteAddr,
-                      const struct sockaddr_in &localAddr,
+                      const struct sockaddr_storage &remoteAddr,
+                      const struct sockaddr_storage &localAddr,
+                      int address_family,
                       bool checkPeer);
 
       virtual int start();
@@ -98,8 +102,9 @@ namespace cannelloni {
   class TCPClientThread : public TCPThread {
   public:
     TCPClientThread(const struct debugOptions_t &debugOptions,
-                    const struct sockaddr_in &remoteAddr,
-                    const struct sockaddr_in &localAddr);
+                    const struct sockaddr_storage &remoteAddr,
+                    const struct sockaddr_storage &localAddr,
+                    int address_family);
     virtual bool attempt_connect();
     virtual void cleanup();
   };

--- a/udpthread.h
+++ b/udpthread.h
@@ -22,6 +22,7 @@
 
 #include <map>
 
+#include <sys/socket.h>
 #include <sys/types.h>
 #include <netinet/in.h>
 
@@ -44,15 +45,16 @@ namespace cannelloni {
 class UDPThread : public ConnectionThread {
   public:
     UDPThread(const struct debugOptions_t &debugOptions,
-              const struct sockaddr_in &remoteAddr,
-              const struct sockaddr_in &localAddr,
+              const struct sockaddr_storage &remoteAddr,
+              const struct sockaddr_storage &localAddr,
+              int address_family,
               bool sort,
               bool checkPeer);
 
     virtual int start();
     virtual void stop();
     virtual void run();
-    bool parsePacket(uint8_t *buf, uint16_t len, struct sockaddr_in &clientAddr);
+    bool parsePacket(uint8_t *buf, uint16_t len, struct sockaddr_storage *clientAddr);
     virtual void transmitFrame(canfd_frame *frame);
 
     void setTimeout(uint32_t timeout);
@@ -70,11 +72,12 @@ class UDPThread : public ConnectionThread {
     bool m_sort;
     bool m_checkPeer;
     int m_socket;
+    int m_address_family;
     Timer m_blockTimer;
     Timer m_transmitTimer;
 
-    struct sockaddr_in m_localAddr;
-    struct sockaddr_in m_remoteAddr;
+    struct sockaddr_storage m_localAddr;
+    struct sockaddr_storage m_remoteAddr;
 
     uint8_t m_sequenceNumber;
     /* Timeout variables */


### PR DESCRIPTION
adds IPv6 support for UDP, TCP and SCTP

IPv4 is default and IPV6 can be selected through the `-6` flag. The flag is inspired by `netcat`

closes #9 