### PR TITLE
cmake: build and link static variant of cannelloni-common

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,10 @@ add_library(cannelloni-common SHARED
             parser.cpp
             decoder.cpp)
 
+add_library(cannelloni-common-static STATIC
+            parser.cpp
+            decoder.cpp)
+
 set_target_properties ( cannelloni-common
   PROPERTIES
   VERSION 0.0.1
@@ -71,7 +75,7 @@ if(SCTP_SUPPORT)
     target_link_libraries(addsources sctpthread)
 endif(SCTP_SUPPORT)
 set_target_properties(addsources PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(cannelloni addsources cannelloni-common pthread)
+target_link_libraries(cannelloni addsources cannelloni-common-static pthread)
 target_compile_features(cannelloni PRIVATE cxx_auto_type)
 target_compile_features(addsources PRIVATE cxx_auto_type)
 


### PR DESCRIPTION
this resolves issues with dynamic linking 

see #47 

The dynamic library is still installed anyway not to break any dependencies to it. I guess the chances are low.