### PR TITLE
CMakeLists.txt: automatically ignore the build directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,11 @@ project(cannelloni)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 
+if(NOT PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
+  # Git auto-ignore out-of-source build directory
+  file(GENERATE OUTPUT .gitignore CONTENT "*")
+endif()
+
 # Options
 option(SCTP_SUPPORT "SCTP_SUPPORT" ON)
 


### PR DESCRIPTION
Create a `.gitignore` file inside the build directory with "*" as its content.