### PR TITLE
CMakeLists.txt: automatically create compile_commands.json file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ cmake_install.cmake
 config.h
 cannelloni
 tags
+compile_commands.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,9 @@ if(NOT PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
   file(GENERATE OUTPUT .gitignore CONTENT "*")
 endif()
 
+# Create compile_commands.json file
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # Options
 option(SCTP_SUPPORT "SCTP_SUPPORT" ON)
 


### PR DESCRIPTION
This creates a `compile_commands.json` file that can then be used by the clangd tool.