### PR TITLE
framebuffer: add configurable frame lifetime and drop stale frames

### DIFF
--- a/cannelloni.cpp
+++ b/cannelloni.cpp
@@ -94,6 +94,7 @@ void printUsage() {
   std::cout << "\t -4 \t\t\t use IPv4 (default)" << std::endl;
   std::cout << "\t -6 \t\t\t use IPv6" << std::endl;
   std::cout << "\t -m \t\t\t set MTU, default: 1500 bytes" << std::endl;
+  std::cout << "\t -g timeout \t\t max frame age in buffer (us), default: 1000000 (0 disables)" << std::endl;
   std::cout << "\t -f \t\t\t fork into background / daemon mode" << std::endl;
   std::cout << "\t -P \t\t\t pid file path (only in daemon mode), default: /var/run/cannelloni.pid" << std::endl;
   std::cout << "\t -h \t\t\t display this help text" << std::endl;
@@ -179,6 +180,7 @@ int main(int argc, char **argv) {
   uint16_t localPort = 20000;
   std::string canInterfaceName = "vcan0";
   uint32_t bufferTimeout = 100000;
+  uint32_t frameLifetime = 1000000;
   std::string timeoutTableFile;
   std::string pidFilePath = "/var/run/cannelloni.pid";
   /* Key is CAN ID, Value is timeout in us */
@@ -186,7 +188,7 @@ int main(int argc, char **argv) {
 
   struct debugOptions_t debugOptions = { /* can */ 0, /* udp */ 0, /* buffer */ 0, /* timer */ 0 };
 
-  const std::string argument_options = "C:l:L:r:R:I:t:T:d:m:P:hsp46f"
+  const std::string argument_options = "C:l:L:r:R:I:t:T:d:m:g:P:hsp46f"
 #ifdef SCTP_SUPPORT
   "S:";
 #else
@@ -294,6 +296,9 @@ int main(int argc, char **argv) {
         break;
       case 'm':
         linkMtuSize = static_cast<uint16_t>(strtol(optarg, NULL, 10));
+        break;
+      case 'g':
+        frameLifetime = static_cast<uint32_t>(strtoul(optarg, NULL, 10));
         break;
       case 'f':
         forkIntoBackground = true;
@@ -487,6 +492,8 @@ int main(int argc, char **argv) {
   auto canThread = std::make_unique<CANThread>(debugOptions, canInterfaceName);
   auto netFrameBuffer = std::make_unique<FrameBuffer>(1000,16000);
   auto canFrameBuffer = std::make_unique<FrameBuffer>(1000,16000);
+  netFrameBuffer->setFrameLifetime(frameLifetime);
+  canFrameBuffer->setFrameLifetime(frameLifetime);
   netThread->setPeerThread(canThread.get());
   netThread->setFrameBuffer(netFrameBuffer.get());
   canThread->setPeerThread(netThread.get());

--- a/framebuffer.cpp
+++ b/framebuffer.cpp
@@ -19,6 +19,7 @@
  */
 
 #include <cstring>
+#include <chrono>
 #include "framebuffer.h"
 #include "logging.h"
 
@@ -28,7 +29,8 @@ FrameBuffer::FrameBuffer(size_t size, size_t max) :
   m_totalAllocCount(0),
   m_bufferSize(0),
   m_intermediateBufferSize(0),
-  m_maxAllocCount(max)
+  m_maxAllocCount(max),
+  m_frameLifetimeUs(0)
 {
   resizePool(size, false);
 }
@@ -39,7 +41,7 @@ FrameBuffer::~FrameBuffer() {
 }
 
 canfd_frame* FrameBuffer::requestFrame(bool overwriteLast, bool debug) {
-  std::lock_guard<std::recursive_mutex> lock(m_poolMutex);
+  std::unique_lock<std::recursive_mutex> poolLock(m_poolMutex);
   if (m_framePool.empty()) {
     bool resizePoolResult;
     if (m_maxAllocCount > 0) {
@@ -65,12 +67,26 @@ canfd_frame* FrameBuffer::requestFrame(bool overwriteLast, bool debug) {
         return NULL;
       }
     } else if(!resizePoolResult && overwriteLast) {
-      std::lock_guard<std::recursive_mutex> lock(m_bufferMutex);
+      std::unique_lock<std::recursive_mutex> bufferLock(m_bufferMutex, std::defer_lock);
+      std::unique_lock<std::recursive_mutex> timestampLock(m_timestampMutex, std::defer_lock);
+      std::lock(bufferLock, timestampLock);
       /*
        * We did reach the limit but we are returning the last frame in the
        * buffer. (ringbuffer behaviour)
        */
-      return requestBufferBack();
+      if (m_buffer.empty()) {
+        return NULL;
+      }
+      canfd_frame *ret = m_buffer.back();
+      m_buffer.pop_back();
+      size_t frameSize = getFrameSize(ret);
+      if (m_bufferSize >= frameSize) {
+        m_bufferSize -= frameSize;
+      } else {
+        m_bufferSize = 0;
+      }
+      m_frameEnqueueTimes.erase(ret);
+      return ret;
     }
   }
   /* If we reach this point, m_framePool is not depleted */
@@ -85,65 +101,96 @@ canfd_frame* FrameBuffer::requestFrame(bool overwriteLast, bool debug) {
 }
 
 void FrameBuffer::insertFramePool(canfd_frame *frame) {
-  std::lock_guard<std::recursive_mutex> lock(m_poolMutex);
+  std::unique_lock<std::recursive_mutex> poolLock(m_poolMutex, std::defer_lock);
+  std::unique_lock<std::recursive_mutex> timestampLock(m_timestampMutex, std::defer_lock);
+  std::lock(poolLock, timestampLock);
 
+  m_frameEnqueueTimes.erase(frame);
   m_framePool.push_back(frame);
 }
 
 void FrameBuffer::insertFrame(canfd_frame *frame) {
-  std::lock_guard<std::recursive_mutex> lock(m_bufferMutex);
+  std::unique_lock<std::recursive_mutex> bufferLock(m_bufferMutex, std::defer_lock);
+  std::unique_lock<std::recursive_mutex> timestampLock(m_timestampMutex, std::defer_lock);
+  std::lock(bufferLock, timestampLock);
 
   m_buffer.push_back(frame);
-  m_bufferSize += CANNELLONI_FRAME_BASE_SIZE + canfd_len(frame);
-
-  /* We need one more byte for CAN_FD Frames */
-  if (frame->len & CANFD_FRAME)
-    m_bufferSize++;
+  m_bufferSize += getFrameSize(frame);
+  if (m_frameEnqueueTimes.find(frame) == m_frameEnqueueTimes.end()) {
+    m_frameEnqueueTimes[frame] = getMonotonicUs();
+  }
 }
 
 void FrameBuffer::returnFrame(canfd_frame *frame) {
-  std::lock_guard<std::recursive_mutex> lock(m_bufferMutex);
+  std::unique_lock<std::recursive_mutex> bufferLock(m_bufferMutex, std::defer_lock);
+  std::unique_lock<std::recursive_mutex> timestampLock(m_timestampMutex, std::defer_lock);
+  std::lock(bufferLock, timestampLock);
 
   m_buffer.push_front(frame);
-  m_bufferSize += CANNELLONI_FRAME_BASE_SIZE + canfd_len(frame);
-  /* We need one more byte for CAN_FD Frames */
-  if (frame->len & CANFD_FRAME)
-    m_bufferSize++;
+  m_bufferSize += getFrameSize(frame);
+  if (m_frameEnqueueTimes.find(frame) == m_frameEnqueueTimes.end()) {
+    m_frameEnqueueTimes[frame] = getMonotonicUs();
+  }
 }
 
 canfd_frame* FrameBuffer::requestBufferFront() {
-  std::lock_guard<std::recursive_mutex> lock(m_bufferMutex);
+  std::unique_lock<std::recursive_mutex> bufferLock(m_bufferMutex, std::defer_lock);
+  std::unique_lock<std::recursive_mutex> poolLock(m_poolMutex, std::defer_lock);
+  std::unique_lock<std::recursive_mutex> timestampLock(m_timestampMutex, std::defer_lock);
+  std::lock(bufferLock, poolLock, timestampLock);
+
   if (m_buffer.empty()) {
     return NULL;
-  }
-  else {
-    canfd_frame *ret = m_buffer.front();
-    m_buffer.pop_front();
-    m_bufferSize -= (CANNELLONI_FRAME_BASE_SIZE + canfd_len(ret));
-    /* We need one more byte for CAN_FD Frames */
-    if (ret->len & CANFD_FRAME)
-      m_bufferSize--;
-    return ret;
+  } else {
+    const uint64_t nowUs = getMonotonicUs();
+    while (!m_buffer.empty()) {
+      canfd_frame *ret = m_buffer.front();
+      m_buffer.pop_front();
+      size_t frameSize = getFrameSize(ret);
+      if (m_bufferSize >= frameSize) {
+        m_bufferSize -= frameSize;
+      } else {
+        m_bufferSize = 0;
+      }
+      if (isFrameExpired(ret, nowUs)) {
+        m_frameEnqueueTimes.erase(ret);
+        m_framePool.push_back(ret);
+        continue;
+      }
+      return ret;
+    }
+    return NULL;
   }
 }
 
 canfd_frame* FrameBuffer::requestBufferBack() {
-  std::lock_guard<std::recursive_mutex> lock(m_bufferMutex);
+  std::unique_lock<std::recursive_mutex> bufferLock(m_bufferMutex, std::defer_lock);
+  std::unique_lock<std::recursive_mutex> poolLock(m_poolMutex, std::defer_lock);
+  std::unique_lock<std::recursive_mutex> timestampLock(m_timestampMutex, std::defer_lock);
+  std::lock(bufferLock, poolLock, timestampLock);
   if (m_buffer.empty()) {
     return NULL;
-  }
-  else {
-    canfd_frame *ret = m_buffer.back();
-    m_buffer.pop_back();
-    m_bufferSize -= (CANNELLONI_FRAME_BASE_SIZE + canfd_len(ret));
-    /* We need one more byte for CAN_FD Frames */
-    if (ret->len & CANFD_FRAME)
-      m_bufferSize--;
-    return ret;
+  } else {
+    const uint64_t nowUs = getMonotonicUs();
+    while (!m_buffer.empty()) {
+      canfd_frame *ret = m_buffer.back();
+      m_buffer.pop_back();
+      size_t frameSize = getFrameSize(ret);
+      if (m_bufferSize >= frameSize) {
+        m_bufferSize -= frameSize;
+      } else {
+        m_bufferSize = 0;
+      }
+      if (isFrameExpired(ret, nowUs)) {
+        m_frameEnqueueTimes.erase(ret);
+        m_framePool.push_back(ret);
+        continue;
+      }
+      return ret;
+    }
+    return NULL;
   }
 }
-
-
 
 void FrameBuffer::swapBuffers() {
   std::unique_lock<std::recursive_mutex> lock1(m_bufferMutex, std::defer_lock);
@@ -163,8 +210,12 @@ void FrameBuffer::sortIntermediateBuffer() {
 void FrameBuffer::mergeIntermediateBuffer() {
   std::unique_lock<std::recursive_mutex> lock1(m_poolMutex, std::defer_lock);
   std::unique_lock<std::recursive_mutex> lock2(m_intermediateBufferMutex, std::defer_lock);
-  std::lock(lock1, lock2);
+  std::unique_lock<std::recursive_mutex> lock3(m_timestampMutex, std::defer_lock);
+  std::lock(lock1, lock2, lock3);
 
+  for (canfd_frame *frame : m_intermediateBuffer) {
+    m_frameEnqueueTimes.erase(frame);
+  }
   m_framePool.splice(m_framePool.end(), m_intermediateBuffer);
   m_intermediateBufferSize = 0;
 }
@@ -172,14 +223,25 @@ void FrameBuffer::mergeIntermediateBuffer() {
 void FrameBuffer::returnIntermediateBuffer(std::list<canfd_frame*>::iterator start) {
   std::unique_lock<std::recursive_mutex> lock1(m_intermediateBufferMutex, std::defer_lock);
   std::unique_lock<std::recursive_mutex> lock2(m_bufferMutex, std::defer_lock);
-  std::lock(lock1,lock2);
+  std::unique_lock<std::recursive_mutex> lock3(m_timestampMutex, std::defer_lock);
+  std::lock(lock1, lock2, lock3);
 
   /* Don't splice since we need to keep track of the size */
   for (std::list<canfd_frame*>::iterator it = start;
                                          it != m_intermediateBuffer.end();) {
     canfd_frame *frame = *it;
     it = m_intermediateBuffer.erase(it);
-    returnFrame(frame);
+    size_t frameSize = getFrameSize(frame);
+    if (m_intermediateBufferSize >= frameSize) {
+      m_intermediateBufferSize -= frameSize;
+    } else {
+      m_intermediateBufferSize = 0;
+    }
+    m_buffer.push_front(frame);
+    m_bufferSize += frameSize;
+    if (m_frameEnqueueTimes.find(frame) == m_frameEnqueueTimes.end()) {
+      m_frameEnqueueTimes[frame] = getMonotonicUs();
+    }
   }
 }
 
@@ -204,24 +266,22 @@ void FrameBuffer::reset() {
   std::unique_lock<std::recursive_mutex> lock1(m_poolMutex, std::defer_lock);
   std::unique_lock<std::recursive_mutex> lock2(m_bufferMutex, std::defer_lock);
   std::unique_lock<std::recursive_mutex> lock3(m_intermediateBufferMutex, std::defer_lock);
-  std::lock(lock1, lock2, lock3);
+  std::unique_lock<std::recursive_mutex> lock4(m_timestampMutex, std::defer_lock);
+  std::lock(lock1, lock2, lock3, lock4);
 
   /* Splice everything back into the pool */
   m_framePool.splice(m_framePool.end(), m_intermediateBuffer);
   m_framePool.splice(m_framePool.end(), m_buffer);
 
+  m_frameEnqueueTimes.clear();
   m_intermediateBufferSize = 0;
   m_bufferSize = 0;
 }
 
 void FrameBuffer::clearPool() {
-  std::unique_lock<std::recursive_mutex> lock1(m_poolMutex, std::defer_lock);
-  std::unique_lock<std::recursive_mutex> lock2(m_bufferMutex, std::defer_lock);
-  std::unique_lock<std::recursive_mutex> lock3(m_intermediateBufferMutex, std::defer_lock);
-  std::lock(lock1, lock2, lock3);
-
   reset();
 
+  std::lock_guard<std::recursive_mutex> lock(m_poolMutex);
   for (canfd_frame *f : m_framePool) {
     delete f;
   }
@@ -245,4 +305,67 @@ bool FrameBuffer::resizePool(std::size_t size, bool debug) {
   if (debug)
     linfo << "New Poolsize:" << m_totalAllocCount << std::endl;
   return true;
+}
+
+void FrameBuffer::setFrameLifetime(uint64_t lifetimeUs) {
+  std::lock_guard<std::recursive_mutex> lock(m_timestampMutex);
+  m_frameLifetimeUs = lifetimeUs;
+}
+
+uint64_t FrameBuffer::getFrameLifetime() {
+  std::lock_guard<std::recursive_mutex> lock(m_timestampMutex);
+  return m_frameLifetimeUs;
+}
+
+void FrameBuffer::dropExpiredIntermediateBuffer() {
+  std::unique_lock<std::recursive_mutex> intermediateBufferLock(m_intermediateBufferMutex, std::defer_lock);
+  std::unique_lock<std::recursive_mutex> poolLock(m_poolMutex, std::defer_lock);
+  std::unique_lock<std::recursive_mutex> timestampLock(m_timestampMutex, std::defer_lock);
+  std::lock(intermediateBufferLock, poolLock, timestampLock);
+
+  if (m_frameLifetimeUs == 0) {
+    return;
+  }
+
+  const uint64_t nowUs = getMonotonicUs();
+  for (auto it = m_intermediateBuffer.begin(); it != m_intermediateBuffer.end();) {
+    canfd_frame *frame = *it;
+    if (!isFrameExpired(frame, nowUs)) {
+      ++it;
+      continue;
+    }
+    size_t frameSize = getFrameSize(frame);
+    if (m_intermediateBufferSize >= frameSize) {
+      m_intermediateBufferSize -= frameSize;
+    } else {
+      m_intermediateBufferSize = 0;
+    }
+    it = m_intermediateBuffer.erase(it);
+    m_frameEnqueueTimes.erase(frame);
+    m_framePool.push_back(frame);
+  }
+}
+
+size_t FrameBuffer::getFrameSize(canfd_frame *frame) {
+  size_t frameSize = CANNELLONI_FRAME_BASE_SIZE + canfd_len(frame);
+  if (frame->len & CANFD_FRAME) {
+    frameSize++;
+  }
+  return frameSize;
+}
+
+uint64_t FrameBuffer::getMonotonicUs() const {
+  auto now = std::chrono::steady_clock::now().time_since_epoch();
+  return std::chrono::duration_cast<std::chrono::microseconds>(now).count();
+}
+
+bool FrameBuffer::isFrameExpired(canfd_frame *frame, uint64_t nowUs) const {
+  if (m_frameLifetimeUs == 0) {
+    return false;
+  }
+  auto it = m_frameEnqueueTimes.find(frame);
+  if (it == m_frameEnqueueTimes.end()) {
+    return false;
+  }
+  return nowUs > it->second && (nowUs - it->second) > m_frameLifetimeUs;
 }

--- a/framebuffer.h
+++ b/framebuffer.h
@@ -22,6 +22,7 @@
 
 #include <list>
 #include <mutex>
+#include <unordered_map>
 #include "cannelloni.h"
 
 namespace cannelloni {
@@ -109,23 +110,36 @@ class FrameBuffer {
     /* Moves all frames back into m_framePool and sets the size to 0 */
     void reset();
 
+    /* Set maximum frame lifetime in us (0 disables age checks) */
+    void setFrameLifetime(uint64_t lifetimeUs);
+
+    uint64_t getFrameLifetime();
+
+    /* Drop expired frames from m_intermediateBuffer */
+    void dropExpiredIntermediateBuffer();
+
     void clearPool();
 
     size_t getFrameBufferSize();
 
   private:
     bool resizePool(std::size_t size, bool debug = false);
+    static size_t getFrameSize(canfd_frame *frame);
+    uint64_t getMonotonicUs() const;
+    bool isFrameExpired(canfd_frame *frame, uint64_t nowUs) const;
 
   private:
     std::list<canfd_frame*> m_framePool;
     std::list<canfd_frame*> m_buffer;
     std::list<canfd_frame*> m_intermediateBuffer;
+    std::unordered_map<canfd_frame*, uint64_t> m_frameEnqueueTimes;
 
     uint64_t m_totalAllocCount;
     /* When filling/swapping the buffers we currently need a mutex */
     std::recursive_mutex m_bufferMutex;
     std::recursive_mutex m_intermediateBufferMutex;
     std::recursive_mutex m_poolMutex;
+    std::recursive_mutex m_timestampMutex;
     /* Track current frame buffer size */
     size_t m_bufferSize;
     size_t m_intermediateBufferSize;
@@ -138,6 +152,7 @@ class FrameBuffer {
      * unlimited
      */
     size_t m_maxAllocCount;
+    uint64_t m_frameLifetimeUs;
 };
 
 }

--- a/tcpthread.cpp
+++ b/tcpthread.cpp
@@ -233,7 +233,13 @@ void TCPThread::flushFrameBuffer() {
   }
   uint8_t transmitBuffer[MAX_TRANSMIT_BUFFER_SIZE_BYTES];
   m_frameBuffer->swapBuffers();
+  m_frameBuffer->dropExpiredIntermediateBuffer();
   std::list<canfd_frame*> *frames = m_frameBuffer->getIntermediateBuffer();
+  if (frames->empty()) {
+    m_frameBuffer->unlockIntermediateBuffer();
+    m_frameBuffer->mergeIntermediateBuffer();
+    return;
+  }
   for (auto it = frames->begin(); it != frames->end(); it++) {
     canfd_frame* frame = *it;
     ssize_t encodedBytes = encodeFrame(transmitBuffer, frame);

--- a/udpthread.cpp
+++ b/udpthread.cpp
@@ -269,8 +269,14 @@ void UDPThread::prepareBuffer() {
   m_frameBuffer->swapBuffers();
   if (m_sort)
     m_frameBuffer->sortIntermediateBuffer();
+  m_frameBuffer->dropExpiredIntermediateBuffer();
 
   std::list<canfd_frame*> *buffer = m_frameBuffer->getIntermediateBuffer();
+  if (buffer->empty()) {
+    m_frameBuffer->unlockIntermediateBuffer();
+    m_frameBuffer->mergeIntermediateBuffer();
+    return;
+  }
 
   auto overflowHandler = [this](std::list<canfd_frame*>&, std::list<canfd_frame*>::iterator it)
   {


### PR DESCRIPTION
Add a configurable frame lifetime for buffered CAN/CAN FD frames.

This change introduces the `-g` command-line option to configure the maximum frame age in microseconds (default: 1000000, `0` disables the check), and passes that setting to both the network and CAN frame buffers.

FrameBuffer now stores an enqueue timestamp for each frame using a monotonic clock and drops expired frames when reading from the main buffer. It also removes expired frames from the intermediate buffer before they can be forwarded.

This avoids replaying large amounts of stale buffered traffic after the bus or transport path recovers.